### PR TITLE
Check appropriate handle exists before evaling it

### DIFF
--- a/nagios/status.rb
+++ b/nagios/status.rb
@@ -24,7 +24,7 @@ module Nagios
                     end
 
                     # end of a section
-                    if line =~ /\}/ && handler != ""
+                    if line =~ /\}/ && handler != "" && Nagios::Status.respond_to?("handle_#{handler}")
                         eval("handle_#{handler}(blocklines)")
                         handler = ""
                     end


### PR DESCRIPTION
If the nagios status file contains certain data (eg the HTML + Javascript of a web page, with { } in it), this can break the parsing done in Nagios::Status. Eg, if Nagios::Status sees this in a line:
`} else {`
it will try to `eval()` a method called `handler_else` which will fail.

This adds a check to make sure the the handler exists before trying to eval it.
