### PR TITLE
When hostname has a dash, rigth pargt of the hostname is cut (after '-')

### DIFF
--- a/nagios/status.rb
+++ b/nagios/status.rb
@@ -326,7 +326,7 @@ module Nagios
             @status["hosts"][host]["hoststatus"] = {} unless @status["hosts"][host]["hoststatus"]
 
             lines.each do |l|
-                if l =~ /\s+(\w+)=(\w+)/
+                if l =~ /\s+(\w+)=(.+)\s*$/
                     @status["hosts"][host]["hoststatus"][$1] = $2
                 end
             end


### PR DESCRIPTION
... (after dash). However dash is a valid symbol for hostname
