### PR TITLE
Tweak to respond_to? code

### DIFF
--- a/nagios/status.rb
+++ b/nagios/status.rb
@@ -24,7 +24,7 @@ module Nagios
                     end
 
                     # end of a section
-                    if line =~ /\}/ && handler != "" && Nagios::Status.respond_to?("handle_#{handler}")
+                    if line =~ /\}/ && handler != "" && self.respond_to?("handle_#{handler}", include_private = true)
                         eval("handle_#{handler}(blocklines)")
                         handler = ""
                     end


### PR DESCRIPTION
Ruby object.respond_to does not return true for private methods (which
is what the parsestatus handlers are.) Tweaked the code so that the test becomes
self.respond_to?(..., include_private = true) to ensure the private
methods are evaluated.
