### PR TITLE
More output for check_check

### DIFF
--- a/bin/check_check
+++ b/bin/check_check
@@ -160,6 +160,14 @@ def main(args)
     end # if results[state]
   end # for each non-OK state
 
+  # If everything is OK, still print detailed output for confirmation
+  if total_results == 0 and results["OK"].size > 0
+      puts "OK Services:"
+      results["OK"].sort { |a,b| a["host_name"] <=> b["host_name"] }.each do |service|
+        puts "  #{service["host_name"]} => #{service["service_description"]}"
+      end
+  end
+
   exitcode = 0
 
   if settings.down_min_percent


### PR DESCRIPTION
This change will make check_check output a list of services in the "OK" state (if any) if there are no other problems reported. This is mainly because it can be difficult to test your regexes with no validating output, and it also provides handy extra detail in the Nagios UI to confirm the list of services that are being checked, even in an OK state. 
