### PR TITLE
ensure status file is parsed in correct encoding

### DIFF
--- a/lib/nagios/status.rb
+++ b/lib/nagios/status.rb
@@ -23,7 +23,7 @@ module Nagios
 
       @status, handler, blocklines = {'hosts' => {}}, '', []
 
-      File.readlines(path).each do |line|
+      File.readlines(path, :encoding => 'iso-8859-1').each do |line|
 
         # start of new sections
         if line =~ /(\w+) \{/


### PR DESCRIPTION
Otherwise throws an exception if there are special characters in the status file
