### PR TITLE
Fix duplicated key warning for CHANGE_HOST_CHECK_TIMEPERIOD

### DIFF
--- a/lib/nagios/external_commands/list.rb
+++ b/lib/nagios/external_commands/list.rb
@@ -38,7 +38,6 @@ module Nagios
       :CHANGE_GLOBAL_HOST_EVENT_HANDLER => %w{event_handler_command},
       :CHANGE_GLOBAL_SVC_EVENT_HANDLER => %w{event_handler_command},
       :CHANGE_HOST_CHECK_COMMAND => %w{host_name check_command},
-      :CHANGE_HOST_CHECK_TIMEPERIOD => %w{host_name check_timeperod},
       :CHANGE_HOST_CHECK_TIMEPERIOD => %w{host_name timeperiod},
       :CHANGE_HOST_EVENT_HANDLER => %w{host_name event_handler_command},
       :CHANGE_HOST_MODATTR => %w{host_name value},


### PR DESCRIPTION
When `require nagios/external_commands/list`, `lib/nagios/external_commands/list.rb:41: warning: duplicated key at line 42 ignored: :CHANGE_HOST_CHECK_TIMEPERIOD` is warned.

This does not break backward compatibility, since previously later key was used.
```
$ irb
> {a: 1, a: 2}
(irb):3: warning: duplicated key at line 3 ignored: :a
=> {:a=>2}
```