### PR TITLE
Remove file read encoding of Nagios status file for Nagios 4

### DIFF
--- a/lib/nagios/status.rb
+++ b/lib/nagios/status.rb
@@ -22,7 +22,7 @@ module Nagios
 
       @status, handler, blocklines = {'hosts' => {}}, '', []
 
-      File.readlines(path, :encoding => 'iso-8859-1').each do |line|
+      File.readlines(path).each do |line|
 
         # start of new sections
         if line =~ /(\w+) \{/


### PR DESCRIPTION
I'm not sure if this just affects Nagios 4, but I at least needed to do this to fix my Nagios 4 install on CentOS 6, as my Nagios 4 status file was `us-ascii`.

### Before:

```
NASSAU [root@<omitted> nagios]# nagsrv -s /var/log/nagios/status.dat
/usr/lib/ruby/gems/1.8/gems/ruby-nagios-0.4.0/lib/nagios/status.rb:25:in `readlines': can't convert Hash into String (TypeError)
        from /usr/lib/ruby/gems/1.8/gems/ruby-nagios-0.4.0/lib/nagios/status.rb:25:in `parsestatus'
        from /usr/lib/ruby/gems/1.8/gems/ruby-nagios-0.4.0/bin/nagsrv:176
        from /usr/bin/nagsrv:19:in `load'
        from /usr/bin/nagsrv:19
```

### After:

```
NASSAU [root@<omitted> nagios]# nagsrv -s /var/log/nagios/status.dat --list-services --with-service /syslog/
check_disk_syslog
```